### PR TITLE
Check directory ownership before chown

### DIFF
--- a/sabnzbd.sh
+++ b/sabnzbd.sh
@@ -33,7 +33,12 @@ echo "[DONE]"
 printf "Set permissions... "
 touch ${CONFIG}
 chown -R ${USER}: /sabnzbd
-chown ${USER}: /datadir /media $(dirname ${CONFIG})
+function check_dir {
+  [ "$(stat -c '%u %g' $1)" == "${SABNZBD_UID} ${SABNZBD_GID}" ] || chown ${USER}: $1
+}
+check_dir /datadir
+check_dir /media
+check_dir $(dirname ${CONFIG})
 echo "[DONE]"
 
 #


### PR DESCRIPTION
chown won't work as root on NFS-mounted directories since the default
option is root_squash. Check first before calling to ensure this
container can run in environments that use NFS.

Fixes #4.