### PR TITLE
Add Travis-CI testing of image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,6 @@ after_script:
 
 after_failure:
   - docker logs sabnzbd
+
+after_success:
+  - docker history dockersabnzbd_sabnzbd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: required
+dist: trusty
+
+services:
+  - docker
+
+install:
+  # Install docker engine from Docker's Ubuntu repo
+  - curl -sSL https://get.docker.com/gpg | sudo -E apt-key add -
+  - echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update
+  - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --assume-yes install docker-engine
+  - docker version
+
+  # Update docker-compose via pip
+  - sudo pip install docker-compose
+  - docker-compose version
+
+before_script:
+  - docker-compose up --build -d
+
+script:
+  - ./test.sh
+
+after_script:
+  - docker-compose down
+
+after_failure:
+  - docker logs sabnzbd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,6 @@ sabnzbd:
     volumes:
         - './data/datadir:/datadir'
         - './data/media:/media'
+    ports:
+        - '8080:8080'
     restart: 'always'

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Simple test script that sees if the SABnzbd server is up within a certain number
+# of seconds (TOTAL_ATTEMPTS * SLEEP_TIME). If it isn't up in time or the HTTP
+# code returned is not 200, then it exits out with an error code.
+
+TOTAL_ATTEMPTS=10
+SLEEP_TIME=6
+
+function connect_server {
+    http_code=$(curl -sL -w "%{http_code}\\n" "http://localhost:8080/" -o /dev/null)
+    curl_exit=$?
+}
+
+attempts=0
+until [ $attempts -ge $TOTAL_ATTEMPTS ]
+do
+    connect_server
+    [ "$curl_exit" == "0" ] && break
+    attempts=$[$attempts+1]
+    sleep $SLEEP_TIME
+done
+
+if [ "$http_code" != "200" ]
+then
+    echo "Received HTTP $http_code from SABnzbd port (last curl exit code: $curl_exit)"
+    exit 1
+fi


### PR DESCRIPTION
This adds a build and simple integration check that SABnzbd actually starts up. Additionally it will give the docker size of each step using the `docker history` command. This should be useful in evaluating whether changes inflate the size of the image too much.