### PR TITLE
Fix locales to handle UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ ADD sabnzbd.sh /sabnzbd.sh
 RUN chmod 755 /sabnzbd.sh
 
 #
+# Fix locales to handle UTF-8 characters.
+#
+
+ENV LANG C.UTF-8
+
+#
 # Install SABnzbd and all required dependencies.
 #
 


### PR DESCRIPTION
This fixes a comment left at https://hub.docker.com/r/sabnzbd/sabnzbd/
regarding German ü characters among other potential issues.