### PR TITLE
Try to remove more packages to make the image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,14 @@ RUN chmod 755 /sabnzbd.sh
 #
 
 RUN export SABNZBD_VERSION=1.2.0 PAR2CMDLINE_VERSION=v0.6.14 \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && export BUILD_PACKAGES="automake build-essential curl" \
+    && export RUNTIME_BACKPORTS_PACKAGES="openssl python-cryptography python-openssl" \
+    && export RUNTIME_PACKAGES="ca-certificates p7zip-full python-cheetah python-yenc unrar unzip" \
     && sed -i "s/ main$/ main contrib non-free/" /etc/apt/sources.list \
     && apt-get -q update \
-    && apt-get -t jessie-backports upgrade -qy openssl \
-    && apt-get install -qy curl ca-certificates python-cheetah python-yenc unzip unrar p7zip-full build-essential automake \
-    && apt-get -t jessie-backports install -qy python-cryptography python-openssl \
+    && apt-get install -qqy $BUILD_PACKAGES $RUNTIME_PACKAGES \
+    && apt-get -t jessie-backports install -qqy $RUNTIME_BACKPORTS_PACKAGES \
     && curl -SL -o /tmp/sabnzbd.tar.gz https://github.com/sabnzbd/sabnzbd/releases/download/${SABNZBD_VERSION}/SABnzbd-${SABNZBD_VERSION}-src.tar.gz \
     && tar xzf /tmp/sabnzbd.tar.gz \
     && mv SABnzbd-* sabnzbd \
@@ -38,8 +41,11 @@ RUN export SABNZBD_VERSION=1.2.0 PAR2CMDLINE_VERSION=v0.6.14 \
     && ./configure \
     && make \
     && make install \
-    && apt-get -y remove curl build-essential automake \
+    && export AUTO_ADDED_PACKAGES="$(apt-mark showauto)" \
+    && apt-get -y remove --purge $BUILD_PACKAGES $AUTO_ADDED_PACKAGES \
     && apt-get -y autoremove \
+    && apt-get install -qqy $RUNTIME_PACKAGES \
+    && apt-get -t jessie-backports install -qqy $RUNTIME_BACKPORTS_PACKAGES \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* \
     && cd / \


### PR DESCRIPTION
This allows a smaller image to be produced by removing more
automatically added packages. However, since it might automatically
remove some of the runtime dependencies, that step must be run twice.

This saves about 11.5 MB (16%) currently.