### PR TITLE
Save some space with -l switch to useradd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Dominique Barton
 #
 
 RUN groupadd -r -g 666 sabnzbd \
-    && useradd -r -u 666 -g 666 -d /sabnzbd sabnzbd
+    && useradd -l -r -u 666 -g 666 -d /sabnzbd sabnzbd
 
 #
 # Add SABnzbd init script.


### PR DESCRIPTION
Usually space is alocated in /var/log/faillog and /var/log/lastlog equal
to highest-UID * constant-size. We don't need that in a Docker image.
This saves 216 kB.