### PR TITLE
TRAVIS: use docker-ce instead of docker-engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ services:
 
 install:
   # Install docker engine from Docker's Ubuntu repo
-  - curl -sSL https://get.docker.com/gpg | sudo -E apt-key add -
-  - echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee -a /etc/apt/sources.list
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu trusty stable"
   - sudo apt-get update
-  - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --assume-yes install docker-engine
+  - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --assume-yes install docker-ce
   - docker version
 
   # Update docker-compose via pip


### PR DESCRIPTION
docker-engine is deprecated thus we use docker-ce instead!
This furthermore solves the following error:

WARNING: The following packages cannot be authenticated!
  docker-engine
E: There were unauthenticated packages and -y was used without \
    --allow-unauthenticated