### PR TITLE
Update sabnzbd to version 2.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG C.UTF-8
 #
 # Specify versions of software to install.
 #
-ARG SABNZBD_VERSION=2.3.3
+ARG SABNZBD_VERSION=2.3.4
 ARG PAR2CMDLINE_VERSION=v0.6.14-mt1
 
 #


### PR DESCRIPTION
Changes:
- Device hostname in hostname-verification always lowercased
- Hostnames ending in ".local" are always accepted
- URLGrabber would not always detect correct filename
- URLGrabber would ignore some successful downloads
- Always send NNTP QUIT after server-test
- Added option "--disable-file-log" to disable file-based logging
- Added CORS-header to API
- Windows: Service compatibility with Windows 10 April update
- Windows: Update Python to 2.7.15
- Windows: Update 7zip to 18.05
- MacOS: Restore compatibility with El Capitan (10.11)