### PR TITLE
Update Sabnzbd version to 2.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG C.UTF-8
 #
 # Specify versions of software to install.
 #
-ARG SABNZBD_VERSION=2.3.4
+ARG SABNZBD_VERSION=2.3.5
 ARG PAR2CMDLINE_VERSION=v0.6.14-mt1
 
 #


### PR DESCRIPTION
#  **Release Notes - SABnzbd 2.3.5**
## **Bug fixes since 2.3.4**

- Reworked Deobfuscate.py script for much faster renaming
- All scripts can now receive input through environment variables
- Unable to set only one Indexer Category per category
- Could falsely report not enough blocks are available for repair
- Failures in un-(7)zip or file-joining would not fail the job
- Direct Unpack could abort unnecessarily
- Rare crash during file assembly
- Server hostname is now used in warnings and logs
- Improved disk performance measurement
- Overall improvements in stability and reliability
- Windows: MultiPar repair of joinable files could fail
- Windows: Tray icon also shows remaining size when paused
- Windows: Wizard would not default to installer language
- Windows: Update MultiPar to 1.3.0.1
- Windows and macOS: Update UnRar to 5.60

Looking for help with SABnzbd development: https://www.reddit.com/r/usenet/comments/918nxv/looking_for_paid_help_with_sabnzbd_development/

## **Upgrading from 2.2.x and older**

- Finish queue
- Stop SABnzbd
- Install new version
- Start SABnzbd

## **Upgrade notices**

- When upgrading from 2.2.0 or older the queue will be converted. Job order, settings and data will be preserved, but all jobs will be unpaused and URL's that did not finish fetching before the upgrade will be lost.
- The organization of the download queue is different from 0.7.x releases. This version will not see the 0.7.x queue, but you can restore the jobs by going to Status page and using Queue Repair. 

## **Known problems and solutions**
Read the file ["ISSUES.txt"](https://github.com/sabnzbd/sabnzbd/blob/develop/ISSUES.txt)

## **About**
SABnzbd is an open-source cross-platform binary newsreader.
It simplifies the process of downloading from Usenet dramatically, thanks
to its web-based user interface and advanced built-in post-processing options
that automatically verify, repair, extract and clean up posts downloaded
from Usenet.

(c) Copyright 2007-2018 by "The SABnzbd-team" <team@sabnzbd.org>