### PR TITLE
Update to 2.3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG C.UTF-8
 #
 # Specify versions of software to install.
 #
-ARG SABNZBD_VERSION=2.3.8
+ARG SABNZBD_VERSION=2.3.9
 ARG PAR2CMDLINE_VERSION=v0.6.14-mt1
 
 #


### PR DESCRIPTION
Changelog as per https://sabnzbd.org/downloads

## Release Notes - SABnzbd 2.3.9
### Improvements and bug fixes since 2.3.8

- Duplicate job detection would not compare job names
- Propagation delay could show even if it was not configured
- Ignore Samples deleted all files of jobs containing the words Sample/Proof
- Warning "Unable to stop the unrar process" was shown too often
- Direct Unpack could hang forever on Unicode downloads
- Test Download could fail if clicked on the icon instead of the button
- Series Duplicate detection did not always work with Direct Unpack enabled
- Adding a job with non-existing category was not set to Default (*) category
- Only delete completed jobs from history when using History Retention option
- Renamed Server Load-balancing to Server IP address selection
- Linux: remove sabnzbd.error.log file at start-up if it grew too large
- ~~Windows: double-click delay increased to avoid accidental pausing~~
- ~~Windows: update MultiPar to v1.3.0.5~~
- ~~Windows and macOS: update UnRar to 5.71~~