### PR TITLE
Feat/sabnzbd upgrade 3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN groupadd -r -g 666 sabnzbd &&\
     chmod 755 /sabnzbd.sh &&\
     tar xzf /tmp/sabnzbd.tar.gz &&\
     mv SABnzbd-* sabnzbd &&\
-    sed -i "s/feedparser/feedparser<6.0.0/" /sabnzbd/requirements.txt &&\
     python3 -m pip install -r /sabnzbd/requirements.txt &&\
     chown -R sabnzbd: sabnzbd &&\
     rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV LANG C.UTF-8
 #
 # Specify versions of software to install.
 #
-ARG SABNZBD_VERSION=3.0.2
+ARG SABNZBD_VERSION=3.1.0
 
 #
 # Add (download) sabnzbd


### PR DESCRIPTION
Updates Sabnbzbd to version 3.1.0 in this image, also resolves https://github.com/domibarton/docker-sabnzbd/issues/40.

Release Notes - SABnzbd 3.1.0
=========================================================

## Changes since 3.0.2
- Added option to automatically deobfuscate final filenames: after unpacking, 
  detect and rename obfuscated or meaningless filenames to the job name, 
  similar to the `Deobfuscate.py` post-processing script. 
- Switched to Transifex as our translations platform:
  Help us translate SABnzbd in your language! Add untranslated texts or 
  improved existing translations here: https://sabnzbd.org/wiki/translate
- Redesigned job availability-check to be more efficient and reliable.
- Scheduled readouts of RSS-feeds would fail silently, they now show a warning.
- Skip repair on Retry if all sets were previously successfully verified.
- Passwords included in the filename no longer have to be at the end.
- Restore limit on length of foldernames (`max_foldername_length`).
- Added password input box on the Add NZB screen. 
- Clear error if `Complete Folder` is set as a subfolder of the `Temporary Folder`.
- Show warning that Pyton 3.5 support will be dropped after 3.1.0.
- Windows/macOS: update UnRar to 5.91 and MultiPar to 1.3.1.0.
- Windows: retry `Access Denied` when renaming files on Windows. 

## Bugfixes since 3.0.2
- Assembler crashes could occur due to race condition in `ArticleCache`.
- On HTTP-redirects the scheme/hostname/port were ignored when behind a proxy.
- Strip slash of the end of `url_base` as it could break other code.
- `Temporary Folder` with unicode characters could result in duplicate unpacking.
- Unpacking with a relative folder set for a category could fail.
- Existing files were not parsed when retrying a job.
- Reading attributes when retrying a job could result in crash.
- Paused priority of pre-queue script was ignored.
- Duplicate Detection did not check filenames in History.
- Downloaded bytes could show as exceeding the total bytes of a job.
- Filtering of history by category would not filter jobs in post-processing.
- Windows: non-Latin languages were displayed incorrectly in the installer.
- Windows: could fail to create folders on some network shares.
- Windows: folders could end in a period, breaking Windows Explorer.

## Upgrade notices
- Jobs that failed on versions before 3.1.x, will throw an error about the 
  attribute file failing to load when they are retried on 3.1.0+. This error 
  can be ignored.
- When upgrading from 2.x.x or older the queue will be converted. Job order,
  settings and data will be preserved, but if you decide to go back to 2.x.x
  your queue cannot be downgraded again. But you can restore the jobs by going
  to the Status page and running Queue Repair.

## Known problems and solutions
- Read the file "ISSUES.txt"

## About
  SABnzbd is an open-source cross-platform binary newsreader.
  It simplifies the process of downloading from Usenet dramatically, thanks
  to its web-based user interface and advanced built-in post-processing options
  that automatically verify, repair, extract and clean up posts downloaded
  from Usenet.

  (c) Copyright 2007-2020 by "The SABnzbd-team" \<team@sabnzbd.org\>
