### PR TITLE
Update to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
-FROM debian:buster
+FROM debian:bullseye-20220125-slim
 
 LABEL maintainer="Dominique Barton"
 
 #
 # Install python and other required packages (https://github.com/sabnzbd/sabnzbd/blob/master/INSTALL.txt#L58)
 #
-RUN export DEBIAN_FRONTEND=noninteractive &&\
-    sed -i "s#deb http://deb.debian.org/debian buster main#deb http://deb.debian.org/debian buster main non-free#g" /etc/apt/sources.list &&\
-    apt-get -q update &&\
-    apt-get install -qqy python3-pip python3-openssl p7zip-full par2 unrar unzip python3 openssl ca-certificates &&\
-    /usr/bin/update-alternatives --install /usr/bin/python python /usr/bin/python3 1 &&\
-    apt-get -y autoremove &&\
-    rm -rf /var/lib/apt/lists/*
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && sed -i "s#deb http://deb.debian.org/debian bullseye main#deb http://deb.debian.org/debian bullseye main non-free#g" /etc/apt/sources.list \
+    && apt-get -q update \
+    && apt-get install -qqy --no-install-recommends \
+      python3-pip \
+      python3-openssl \
+      p7zip-full \
+      par2 \
+      unrar \
+      unzip \
+      python3 \
+      openssl \
+      ca-certificates \
+      build-essential \
+      libssl-dev \
+      libffi-dev \
+      python3-dev \
+      cargo \
+    && /usr/bin/update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 #
 # Add SABnzbd init script.
@@ -36,15 +48,24 @@ ADD https://github.com/sabnzbd/sabnzbd/releases/download/${SABNZBD_VERSION}/SABn
 #
 # Install SABnzbd and requied dependencies (https://github.com/sabnzbd/sabnzbd/blob/master/INSTALL.txt#L67)
 #
-RUN groupadd -r -g 666 sabnzbd &&\
-    useradd -l -r -u 666 -g 666 -d /sabnzbd sabnzbd &&\
-    chmod 755 /sabnzbd.sh &&\
-    tar xzf /tmp/sabnzbd.tar.gz &&\
-    mv SABnzbd-* sabnzbd &&\
-    python3 -m pip install -r /sabnzbd/requirements.txt &&\
-    chown -R sabnzbd: sabnzbd &&\
-    chmod +x /sabnzbd/scripts/Deobfuscate.py &&\
-    rm -rf /tmp/*
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && groupadd -r -g 666 sabnzbd \
+    && useradd -l -r -u 666 -g 666 -d /sabnzbd sabnzbd \
+    && chmod 755 /sabnzbd.sh \
+    && tar xzf /tmp/sabnzbd.tar.gz \
+    && mv SABnzbd-* sabnzbd \
+    && python3 -m pip install -r /sabnzbd/requirements.txt \
+    && chown -R sabnzbd: sabnzbd \
+    && chmod +x /sabnzbd/scripts/Deobfuscate.py \
+    && apt-get remove -qy \
+      build-essential \
+      libssl-dev \
+      libffi-dev \
+      python3-dev \
+      cargo \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/*
 
 #
 # Define container settings.


### PR DESCRIPTION
The cryptography package is no longer prebuilt on buster, so upgrade
to bullseye so we do not have to install rust during docker build.